### PR TITLE
Trying to complete the user management for authorization sections, ru…

### DIFF
--- a/SIMPL/SIMPL/Controllers/HomeController.cs
+++ b/SIMPL/SIMPL/Controllers/HomeController.cs
@@ -8,6 +8,21 @@ using SIMPL.Models;
 
 namespace SIMPL.Controllers
 {
+    public class AccountController : Controller
+    {
+        public IActionResult Login()
+        {
+            return View("Areas/Identity/Pages/Account/Login.cshtml");
+        }
+
+        public IActionResult Forbidden()
+        {
+            return View();
+        }
+    }
+
+
+    [Microsoft.AspNetCore.Authorization.Authorize]
     public class HomeController : Controller
     {
         public IActionResult Index()

--- a/SIMPL/SIMPL/GlobalSuppressions.cs
+++ b/SIMPL/SIMPL/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>", Scope = "namespace", Target = "~N:SIMPL.Models")]
+

--- a/SIMPL/SIMPL/Models/project_trackerContext.cs
+++ b/SIMPL/SIMPL/Models/project_trackerContext.cs
@@ -5,7 +5,7 @@ using Microsoft.IdentityModel;
 
 namespace SIMPL.Models
 {
-    public class project_trackerContext : DbContext //used to say public partial class
+    public class project_trackerContext : DbContext //previously said public partial class
     {
         public virtual DbSet<AspNetRoleClaims> AspNetRoleClaims { get; set; }
         public virtual DbSet<AspNetRoles> AspNetRoles { get; set; }

--- a/SIMPL/SIMPL/Startup.cs
+++ b/SIMPL/SIMPL/Startup.cs
@@ -7,6 +7,12 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using SIMPL;
+using SIMPL.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using SIMPL.Areas.Identity;
 //using EFGetStarted.AspNetCore.ExistingDb.Models; https://docs.microsoft.com/en-us/ef/core/get-started/aspnetcore/existing-db#register-your-context-with-dependency-injection
 
 
@@ -24,7 +30,13 @@ namespace SIMPL
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            
+
+            services.AddDbContext<Models.project_trackerContext>(options =>
+                options.UseSqlServer(
+                    Configuration.GetConnectionString("csConnection")));
+            services.AddDefaultIdentity<IdentityUser>().AddRoles<IdentityRole>()
+                 .AddEntityFrameworkStores<Models.project_trackerContext>();
+
             services.AddMvc();
         }
 


### PR DESCRIPTION
…nning into an issue with the DB context Create. Run project for error message.

ArgumentException: AddDbContext was called with configuration, but the context type 'project_trackerContext' only declares a parameterless constructor. This means that the configuration passed to AddDbContext will never be used. If configuration is passed to AddDbContext, then 'project_trackerContext' should declare a constructor that accepts a DbContextOptions<project_trackerContext> and must pass it to the base constructor for DbContext.
Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.CheckContextConstructors<TContext>()